### PR TITLE
Add .Send() to log lines to terminate the server

### DIFF
--- a/server/cmd/root.go
+++ b/server/cmd/root.go
@@ -27,16 +27,16 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		config, err := cmd.Flags().GetString("config")
 		if err != nil {
-			log.Fatal().Err(err)
+			log.Fatal().Err(err).Send()
 		}
 		server, err := routes.NewServer(config)
 		if err != nil {
-			log.Fatal().Err(err)
+			log.Fatal().Err(err).Send()
 		}
 
 		err = server.Start()
 		if err != nil {
-			log.Fatal().Err(err)
+			log.Fatal().Err(err).Send()
 		}
 	},
 }


### PR DESCRIPTION
### Description

Stop the server from panicing by terminating the server on error

### Related Issues

#49 
